### PR TITLE
Allow builds on non-master branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ install:
 # before the next command is issued.
 script:
   - make &&
-    $GOPATH/bin/dg-scrape &&
-    $GOPATH/bin/dg-enrich-songs &&
-    $GOPATH/bin/dg-create-playlists &&
-    $GOPATH/bin/dg-build &&
+    make scrape &&
+    make enrich-songs &&
+    make create-playlists &&
+    TARGET_DIR=./public make build &&
     TARGET_DIR=./public S3_BUCKET=deathguild-playlists make deploy
 
 # Unfortunately we cannot dump the database currently because of a version

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,11 @@ clean:
 	mkdir -p public/
 	rm -f -r public/*
 
+create-playlists:
+ifdef REFRESH_TOKEN
+	$(GOPATH)/bin/dg-create-playlists
+endif
+
 # Long TTL (in seconds) to set on an object in S3. This is suitable for items
 # that we expect to only have to invalidate very rarely like images. Although
 # we set it for all assets, those that are expected to change more frequently
@@ -74,6 +79,11 @@ ifdef DATABASE_URL
 	psql $(DATABASE_URL) < $(TARGET_DIR)/deathguild.sql
 endif
 
+enrich-songs:
+ifdef REFRESH_TOKEN
+	$(GOPATH)/bin/dg-enrich-songs
+endif
+
 install:
 	go install $(shell go list ./... | egrep -v '/vendor/')
 
@@ -85,6 +95,9 @@ install:
 # to the entire command.
 lint:
 	go list ./... | egrep -v '/vendor/' | sed "s|^github\.com/brandur/sorg|.|" | xargs -I{} -n1 sh -c '$(GOPATH)/bin/golint -set_exit_status {} || exit 255'
+
+scrape:
+	$(GOPATH)/bin/dg-scrape
 
 serve:
 	$(GOPATH)/bin/dg-serve


### PR DESCRIPTION
Put build steps requiring secrets behind gates in the `Makefile` so that
the build could plausibly succeed on non-`master` branches (encrypted
environment variables are only available on `master`).