### PR TITLE
Better logging + more quiet output

### DIFF
--- a/cmd/dg-build/main.go
+++ b/cmd/dg-build/main.go
@@ -7,11 +7,11 @@ import (
 	"html/template"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
 	"strings"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/brandur/deathguild"
 	"github.com/brandur/sorg/pool"
 	"github.com/joeshaw/envdecode"
@@ -177,7 +177,7 @@ func buildPlaylistInTransaction(txn *sql.Tx, playlist *deathguild.Playlist) erro
 // Note that this function was copied wholesale from sorg and should probably
 // be shared between projects.
 func compileJavascripts(inPath, outPath string) error {
-	log.Printf("Building: %v", outPath)
+	log.Infof("Building: %v", outPath)
 
 	javascriptInfos, err := ioutil.ReadDir(inPath)
 	if err != nil {
@@ -195,7 +195,7 @@ func compileJavascripts(inPath, outPath string) error {
 			continue
 		}
 
-		log.Printf("Including: %v", javascriptInfo.Name())
+		log.Debugf("Including: %v", javascriptInfo.Name())
 
 		inFile, err := os.Open(path.Join(inPath, javascriptInfo.Name()))
 		if err != nil {
@@ -247,7 +247,7 @@ func compileStylesheets(inPath, outPath string) error {
 			continue
 		}
 
-		log.Printf("Including: %v", stylesheetInfo.Name())
+		log.Debugf("Including: %v", stylesheetInfo.Name())
 
 		inFile, err := os.Open(path.Join(inPath, stylesheetInfo.Name()))
 		if err != nil {

--- a/cmd/dg-create-playlists/main.go
+++ b/cmd/dg-create-playlists/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"database/sql"
 	"fmt"
-	"log"
 	"os"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/brandur/deathguild"
 	"github.com/brandur/sorg/pool"
 	"github.com/joeshaw/envdecode"
@@ -110,7 +110,7 @@ func createPlaylist(name string) (spotify.ID, error) {
 		return spotify.ID(""), err
 	}
 
-	log.Printf(`Created playlist: "%v"`, name)
+	log.Debugf(`Created playlist: "%v"`, name)
 	return playlist.SimplePlaylist.ID, nil
 }
 
@@ -127,7 +127,7 @@ func createPlaylistWithSongs(txn *sql.Tx, playlistMap map[string]spotify.ID,
 			return err
 		}
 	} else {
-		log.Printf(`Found cached playlist: "%v" (ID %v)`, name, playlistID)
+		log.Debugf(`Found cached playlist: "%v" (ID %v)`, name, playlistID)
 	}
 
 	var songIDs []spotify.ID
@@ -148,7 +148,7 @@ func createPlaylistWithSongs(txn *sql.Tx, playlistMap map[string]spotify.ID,
 		return err
 	}
 
-	log.Printf(`Updated playlist: "%v" (ID %v) with %v song(s)`,
+	log.Debugf(`Updated playlist: "%v" (ID %v) with %v song(s)`,
 		name, playlistID, len(playlist.Songs))
 	return nil
 }
@@ -198,7 +198,7 @@ func getPlaylistMap() (map[string]spotify.ID, error) {
 		offset += len(page.Playlists)
 	}
 
-	log.Printf("Cached %v playlist(s)", len(playlistMap))
+	log.Infof("Cached %v playlist(s)", len(playlistMap))
 	return playlistMap, nil
 }
 
@@ -238,7 +238,7 @@ func playlistsNeedingID(txn *sql.Tx, limit int) ([]*deathguild.Playlist, error) 
 		}
 	}
 
-	log.Printf("Found %v playlist(s) needing Spotify IDs", len(playlists))
+	log.Infof("Found %v playlist(s) needing Spotify IDs", len(playlists))
 	return playlists, nil
 }
 
@@ -278,7 +278,7 @@ func runLoop() (bool, int, error) {
 		return true, 1, nil
 	}
 
-	log.Printf("Created %v Spotify playlist(s)", len(playlists))
+	log.Infof("Created %v Spotify playlist(s)", len(playlists))
 	return false, 0, nil
 }
 

--- a/cmd/dg-enrich-songs/main.go
+++ b/cmd/dg-enrich-songs/main.go
@@ -3,12 +3,12 @@ package main
 import (
 	"database/sql"
 	"fmt"
-	"log"
 	"math/rand"
 	"os"
 	"sync/atomic"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/brandur/deathguild"
 	"github.com/brandur/sorg/pool"
 	"github.com/joeshaw/envdecode"
@@ -90,7 +90,7 @@ func retrieveID(txn *sql.Tx, song *deathguild.Song, numNotFound *int64) error {
 	song.SpotifyCheckedAt = time.Now()
 
 	if len(res.Tracks.Tracks) < 1 {
-		log.Printf("Song not found: %+v", song)
+		log.Debugf("Song not found: %+v", song)
 		atomic.AddInt64(numNotFound, 1)
 
 		err = updateSong(txn, song)
@@ -103,7 +103,7 @@ func retrieveID(txn *sql.Tx, song *deathguild.Song, numNotFound *int64) error {
 
 	track := res.Tracks.Tracks[0]
 
-	log.Printf("Got track ID: %v (original: %v - %v) (Spotify: %v - %v)",
+	log.Debugf("Got track ID: %v (original: %v - %v) (Spotify: %v - %v)",
 		string(track.ID),
 		song.Artist, song.Title,
 		artistsToString(track.Artists), track.Name)
@@ -117,7 +117,7 @@ func retrieveID(txn *sql.Tx, song *deathguild.Song, numNotFound *int64) error {
 
 	// be kind and rate limit our requests
 	t := rand.Float32()
-	log.Printf("Sleeping %v seconds", t)
+	log.Debugf("Sleeping %v seconds", t)
 	time.Sleep(time.Duration(t) * time.Second)
 
 	return nil
@@ -160,7 +160,7 @@ func runLoop() (bool, int, error) {
 		return true, 1, nil
 	}
 
-	log.Printf("Retrieved %v Spotify ID(s); failed to find %v",
+	log.Infof("Retrieved %v Spotify ID(s); failed to find %v",
 		len(songs)-int(numNotFound), numNotFound)
 	return false, 0, nil
 }
@@ -197,7 +197,7 @@ func songsNeedingID(txn *sql.Tx, limit int) ([]*deathguild.Song, error) {
 		songs = append(songs, &song)
 	}
 
-	log.Printf("Found %v songs needing Spotify IDs", len(songs))
+	log.Infof("Found %v songs needing Spotify IDs", len(songs))
 	return songs, nil
 }
 

--- a/cmd/dg-scrape/main.go
+++ b/cmd/dg-scrape/main.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
-	"log"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -12,6 +11,7 @@ import (
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
+	log "github.com/Sirupsen/logrus"
 	"github.com/brandur/deathguild"
 	"github.com/brandur/sorg/pool"
 	"github.com/joeshaw/envdecode"
@@ -58,7 +58,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	log.Printf("Requesting index at: %v", indexURL)
+	log.Infof("Requesting index at: %v", indexURL)
 	resp, err := http.Get(indexURL)
 	if err != nil {
 		log.Fatal(err)
@@ -108,7 +108,7 @@ func scrapeIndex(r io.Reader) ([]PlaylistLink, error) {
 		return nil, outErr
 	}
 
-	log.Printf("Found %v playlist(s) in index", len(links))
+	log.Infof("Found %v playlist(s) in index", len(links))
 	return links, nil
 }
 
@@ -139,11 +139,11 @@ func handlePlaylist(link PlaylistLink) error {
 	).Scan(&playlistID)
 
 	if playlistID != 0 {
-		log.Printf("Playlist %v already handled; skipping", day)
+		log.Debugf("Playlist %v already handled; skipping", day)
 		return nil
 	}
 
-	log.Printf("Requesting playlist at: %v", darkdbURL+"/"+link)
+	log.Debugf("Requesting playlist at: %v", darkdbURL+"/"+link)
 	resp, err := http.Get(darkdbURL + "/" + string(link))
 	if err != nil {
 		return err
@@ -162,7 +162,7 @@ func handlePlaylist(link PlaylistLink) error {
 
 	// be kind and rate limit our requests
 	t := 1 + rand.Float32()
-	log.Printf("Sleeping %v seconds", t)
+	log.Debugf("Sleeping %v seconds", t)
 	time.Sleep(time.Duration(t) * time.Second)
 
 	return nil
@@ -214,7 +214,7 @@ func upsertPlaylistAndSongs(txn *sql.Tx, day string,
 		}
 	}
 
-	log.Printf("Inserted records for %v song(s)", len(songs))
+	log.Infof("Inserted records for %v song(s)", len(songs))
 	return nil
 }
 
@@ -243,6 +243,6 @@ func scrapePlaylist(r io.Reader) ([]*deathguild.Song, error) {
 		return nil, outErr
 	}
 
-	log.Printf("Found playlist of %v song(s)", len(songs))
+	log.Infof("Found playlist of %v song(s)", len(songs))
 	return songs, nil
 }

--- a/cmd/dg-scrape/main_test.go
+++ b/cmd/dg-scrape/main_test.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"log"
 	"os"
 	"testing"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/brandur/deathguild"
 	tt "github.com/brandur/deathguild/testing"
 	assert "github.com/stretchr/testify/require"
@@ -68,7 +68,7 @@ func TestUpsertPlaylistAndSongs(t *testing.T) {
 	).Scan(&playlistID)
 	assert.NoError(t, err)
 
-	log.Printf("New playlist ID is %v", playlistID)
+	log.Debugf("New playlist ID is %v", playlistID)
 	assert.NotEqual(t, 0, playlistID)
 
 	for _, song := range songs {
@@ -81,7 +81,7 @@ func TestUpsertPlaylistAndSongs(t *testing.T) {
 		).Scan(&songID)
 		assert.NoError(t, err)
 
-		log.Printf("New song ID for %v - %v is %v",
+		log.Debugf("New song ID for %v - %v is %v",
 			song.Artist, song.Title, songID)
 		assert.NotEqual(t, 0, songID)
 
@@ -94,7 +94,7 @@ func TestUpsertPlaylistAndSongs(t *testing.T) {
 		).Scan(&playlistSongID)
 		assert.NoError(t, err)
 
-		log.Printf("New playlist/song join ID for %v - %v is %v",
+		log.Debugf("New playlist/song join ID for %v - %v is %v",
 			song.Artist, song.Title, playlistSongID)
 		assert.NotEqual(t, 0, songID)
 	}

--- a/cmd/dg-serve/main.go
+++ b/cmd/dg-serve/main.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"log"
 	"net/http"
 	"path"
 	"strconv"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/brandur/deathguild"
 	"github.com/joeshaw/envdecode"
 )
@@ -41,8 +41,8 @@ func main() {
 }
 
 func serve(targetDir string, port int) error {
-	log.Printf("Serving '%v' on port %v", path.Clean(targetDir), port)
-	log.Printf("Open browser to: http://localhost:%v/", port)
+	log.Infof("Serving '%v' on port %v", path.Clean(targetDir), port)
+	log.Infof("Open browser to: http://localhost:%v/", port)
 	handler := http.FileServer(http.Dir(targetDir))
 	return http.ListenAndServe(":"+strconv.Itoa(port), handler)
 }

--- a/deathguild.go
+++ b/deathguild.go
@@ -2,11 +2,11 @@ package deathguild
 
 import (
 	"database/sql"
-	"log"
 	"os"
 	"path"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/brandur/sorg/pool"
 )
 
@@ -132,7 +132,7 @@ func CreateOutputDirs(targetDir string) error {
 // if all tasks succeeded. If a false is returned, the caller should consider
 // exiting with non-zero status.
 func RunTasks(concurrency int, tasks []*pool.Task) bool {
-	log.Printf("Running %v task(s) with concurrency %v",
+	log.Infof("Running %v task(s) with concurrency %v",
 		len(tasks), concurrency)
 
 	p := pool.NewPool(tasks, concurrency)
@@ -141,11 +141,11 @@ func RunTasks(concurrency int, tasks []*pool.Task) bool {
 	var numErrors int
 	for _, task := range p.Tasks {
 		if task.Err != nil {
-			log.Printf("Error: %v", task.Err.Error())
+			log.Errorf("Error: %v", task.Err.Error())
 			numErrors++
 		}
 		if numErrors >= 10 {
-			log.Printf("Too many errors.")
+			log.Errorf("Too many errors.")
 			break
 		}
 	}


### PR DESCRIPTION
Move to a logging library that actually has levels so that we can
relegate a lot of noisy information to DEBUG. This makes logs easier to
grok but also allows us to delve into the data if necessary.