### PR TITLE
Use a compressed version of the database dump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ script:
   - mkdir $TARGET_DIR &&
     make &&
     make database-fetch &&
+    make database-decompress &&
     make database-restore &&
     make scrape-playlists &&
     CONCURRENCY=1 make enrich-songs
@@ -47,6 +48,10 @@ script:
   - CONCURRENCY=1 make create-playlists
 
   - make database-dump &&
+    make database-compress &&
+    # Remove the larger non-compressed file so we don't waste the bandwidth
+    # everytime.
+    rm -f public/deathguild.sql &&
     make build-site &&
     make deploy-site
 

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,12 @@ else
 	# No AWS access key. Skipping deploy.
 endif
 
+database-compress: check-target-dir
+	gzip -c --force $(TARGET_DIR)/deathguild.sql > $(TARGET_DIR)/deathguild.sql.gz
+
+database-decompress: check-target-dir
+	gzip -d --force --stdout $(TARGET_DIR)/deathguild.sql.gz > $(TARGET_DIR)/deathguild.sql
+
 # Produces a database backup. This is so that we can throw one in S3 during
 # deployment in case we lose a database or a database provider.
 database-dump: check-target-dir

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ Then to dump it back:
 export S3_BUCKET=deathguild-playlists
 
 make database-dump
-aws s3 cp $TARGET_DIR/deathguild.sql s3://$S3_BUCKET/ --acl public-read
+make database-compress
+aws s3 cp $TARGET_DIR/deathguild.sql.gz s3://$S3_BUCKET/ --acl public-read
 ```
 
 ## Testing


### PR DESCRIPTION
Uses a compressed version of the database dump so that less bandwidth is
needed to transfer the file down before the build and up after it.