### PR TITLE
Upgrade to Go 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.8
+  - "1.11"
 
 # specified explicitly so we can we can get Postgres 9.5
 dist: trusty


### PR DESCRIPTION
The Go team broke Golint for 1.8 because it has fallen slightly out of
their aggressive support schedule. Upgrade to Go 1.11 so that the build
works again.